### PR TITLE
[Modify] User login, User API Unit Test

### DIFF
--- a/users/tests.py
+++ b/users/tests.py
@@ -133,8 +133,8 @@ class WesaladSignUpTest(APITestCase):
             {
                 'name'          : 'test_user',
                 'ordinal_number': 31,
-                'answers'       : 'answer_test_description_1,answer_test_description_2,answer_test_description_3,answer_test_description_4,answer_test_description_20',
-                'stacks'        : 'stack_test_title_1,stack_test_title_2'
+                'answers'       : '1,2,3,4,20',
+                'stacks'        : '1,2'
              },
             format='json')
         print(response.content)
@@ -234,8 +234,8 @@ class ProfileTest(APITestCase):
             {
                 'name'          : 'test_user_updated',
                 'ordinal_number': 19,
-                'answers'       : 'answer_test_description_1,answer_test_description_2,answer_test_description_3,answer_test_description_2,answer_test_description_19',
-                'stacks'        : 'stack_test_title_3,stack_test_title_4'
+                'answers'       : '1,2,3,19',
+                'stacks'        : '3,4'
              },
             format='json', **header)
         print(response.content)
@@ -249,8 +249,8 @@ class ProfileTest(APITestCase):
             {
                 'name'          : 'test_user_updated',
                 'ordinal_number': 19,
-                'answers'       : 'answer_test_description_1,answer_test_description_2,answer_test_description_3,answer_test_description_2,answer_test_description_19',
-                'stacks'        : 'stack_test_title_3,stack_test_title_4'
+                'answers'       : '1,2,3,19',
+                'stacks'        : '3,4'
              },
             format='json')
         print(response.content)
@@ -265,8 +265,8 @@ class ProfileTest(APITestCase):
             {
                 'name'          : 'test_user_updated',
                 'ordinal_number': 19,
-                'answers'       : 'answer_test_description_50',
-                'stacks'        : 'stack_test_title_3'
+                'answers'       : '50',
+                'stacks'        : '3'
              },
             format='json', **header)
         print(response.content)
@@ -281,8 +281,8 @@ class ProfileTest(APITestCase):
             {
                 'name'          : 'test_user_updated',
                 'ordinal_number': 19,
-                'answers'       : 'answer_test_description_4',
-                'stacks'        : 'stack_test_title_50'
+                'answers'       : '4',
+                'stacks'        : '50'
              },
             format='json', **header)
         print(response.content)
@@ -297,8 +297,8 @@ class ProfileTest(APITestCase):
             {
                 'name'          : 'test_user_updated',
                 'ordinal_number': 'df',
-                'answers'       : 'answer_test_description_4',
-                'stacks'        : 'stack_test_title_3'
+                'answers'       : '4',
+                'stacks'        : '3'
              },
             format='json', **header)
         print(response.json())

--- a/users/views.py
+++ b/users/views.py
@@ -44,10 +44,13 @@ class GoogleSignInAPI(APIView):
 
         if not user_filter.exists()\
             or not True in [user.is_active for user in user_filter]:
-            return Response({'google_account' : google_account.id}, status=status.HTTP_200_OK)
+            return Response({'google_account_id' : google_account.id, 'image_url' : google_account.image_url}, status=status.HTTP_200_OK)
         
         user  = User.objects.get(google_account=google_account, is_active=True)
         token = self.generate_jwt(user)
+        
+        token['user_id']   = user.id
+        token['user_name'] = user.name
                 
         return Response(token, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
유저 로그인시 유저의 토큰과함께 이름과 id값을 보내주도록 수정.

유저 회원가입을 해야할 시 구글소셜어카운트 데이터의 id 값과, image_url을 함께주도록 수정

User Unit Test 수정.