### PR TITLE
[MODIFY] users api

### DIFF
--- a/backend/apps/users/tests.py
+++ b/backend/apps/users/tests.py
@@ -232,13 +232,11 @@ class ProfileTest(APITestCase):
     # Profile Update
     def test_success_wesalad_user_profile_update(self):
         header   = {'HTTP_access' : self.access_token}
-        response = self.client.put(
+        response = self.client.patch(
             f'{self.test_url}', 
             {
                 'name'          : 'test_user_updated',
-                'ordinal_number': 19,
-                'answers'       : 'answer_test_description_1,answer_test_description_2,answer_test_description_3,answer_test_description_19',
-                'stacks'        : 'stack_test_title_3,stack_test_title_4'
+                'ordinal_number': 19,                
              },
             format='json', **header)
         print(response.content)
@@ -247,13 +245,11 @@ class ProfileTest(APITestCase):
         self.assertEqual(response.json()['name'], 'test_user_updated')
     
     def test_fail_wesalad_user_profile_update_without_token(self):
-        response = self.client.put(
+        response = self.client.patch(
             f'{self.test_url}', 
             {
                 'name'          : 'test_user_updated',
                 'ordinal_number': 19,
-                'answers'       : 'answer_test_description_1,answer_test_description_2,answer_test_description_3,answer_test_description_19',
-                'stacks'        : 'stack_test_title_3,stack_test_title_4'
              },
             format='json')
         print(response.content)
@@ -261,47 +257,45 @@ class ProfileTest(APITestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.content, b'{"ERROR":"DECODE_ERROR"}')
     
-    def test_fail_wesalad_user_profile_update_with_wrong_answer_information(self):
-        header   = {'HTTP_access' : self.access_token}
-        response = self.client.put(
-            f'{self.test_url}', 
-            {
-                'name'          : 'test_user_updated',
-                'ordinal_number': 19,
-                'answers'       : 'answer_test_description_50',
-                'stacks'        : 'stack_test_title_3,stack_test_title_4'
-             },
-            format='json', **header)
-        print(response.content)
-    
-        self.assertEqual(response.status_code, 400)    
-        self.assertEqual(response.content, b'{"ERROR":"ANSWER_MATCHING_QUERY_DOES_NOT_EXIST."}')
-    
-    def test_fail_wesalad_user_profile_update_with_wrong_stack_information(self):
-        header   = {'HTTP_access' : self.access_token}
-        response = self.client.put(
-            f'{self.test_url}', 
-            {
-                'name'          : 'test_user_updated',
-                'ordinal_number': 19,
-                'answers'       : 'answer_test_description_4',
-                'stacks'        : 'stack_test_title_50'
-             },
-            format='json', **header)
-        print(response.content)
-    
-        self.assertEqual(response.status_code, 400)    
-        self.assertEqual(response.content, b'{"ERROR":"STACK_MATCHING_QUERY_DOES_NOT_EXIST."}')
+    # def test_fail_wesalad_user_profile_update_with_wrong_answer_information(self):
+    #     header   = {'HTTP_access' : self.access_token}
+    #     response = self.client.put(
+    #         f'{self.test_url}', 
+    #         {
+    #             'name'          : 'test_user_updated',
+    #             'ordinal_number': 19,
+    #             'answers'       : 'answer_test_description_50',
+    #             'stacks'        : 'stack_test_title_3,stack_test_title_4'
+    #          },
+    #         format='json', **header)
+    #     print(response.content)
+    # 
+    #     self.assertEqual(response.status_code, 400)    
+    #     self.assertEqual(response.content, b'{"ERROR":"ANSWER_MATCHING_QUERY_DOES_NOT_EXIST."}')
+    # 
+    # def test_fail_wesalad_user_profile_update_with_wrong_stack_information(self):
+    #     header   = {'HTTP_access' : self.access_token}
+    #     response = self.client.put(
+    #         f'{self.test_url}', 
+    #         {
+    #             'name'          : 'test_user_updated',
+    #             'ordinal_number': 19,
+    #             'answers'       : 'answer_test_description_4',
+    #             'stacks'        : 'stack_test_title_50'
+    #          },
+    #         format='json', **header)
+    #     print(response.content)
+    # 
+    #     self.assertEqual(response.status_code, 400)    
+    #     self.assertEqual(response.content, b'{"ERROR":"STACK_MATCHING_QUERY_DOES_NOT_EXIST."}')
     
     def test_fail_wesalad_user_profile_update_with_wrong_type(self):
         header   = {'HTTP_access' : self.access_token}
-        response = self.client.put(
+        response = self.client.patch(
             f'{self.test_url}', 
             {
                 'name'          : 'test_user_updated',
                 'ordinal_number': 'df',
-                'answers'       : 'answer_test_description_4',
-                'stacks'        : 'stack_test_title_3'
              },
             format='json', **header)
         print(response.json())

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -15,7 +15,7 @@ from django.contrib.auth    import get_user_model
 from apps.utils.decorators  import check_token
 from apps.utils.utils       import error_message
 from .models                import GoogleSocialAccount
-from .serializers           import UserSerializer, UserCreateSerializer
+from .serializers           import UserSerializer, UserCreateSerializer, UserUpdateSerializer
 
 User = get_user_model()
 
@@ -134,15 +134,11 @@ class ProfileAPI(APIView):
         try:
             user = request.user
             
-            serializer = UserSerializer(user, data=request.data)
-            answers    = request.data.get('answers')
-            stacks     = request.data.get('stacks')
+            serializer = UserUpdateSerializer(user, data=request.data)
             
             if serializer.is_valid():
-                serializer.save(
-                    answers = answers,
-                    stacks = stacks
-                )
+                serializer.save()
+                
                 return Response(serializer.data, status=status.HTTP_201_CREATED)
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
         except ValueError:


### PR DESCRIPTION
근휘님이 요청하신부분에 맞게 users API 수정.
그에 맞게 테스트코드도 수정.

유저 profile GET 요청시 또는, 회원가입 완료시 프론트에게 전달하는 데이터의 answers의 이미지를 줄 수 있도록 수정.

유저 업데이트시에는 성향은 바꿀 수 없도록 수정.

