### PR TITLE
myposts 페이지 레이아웃 및 데이터 렌더링 완료

### DIFF
--- a/frontend/src/Router.js
+++ b/frontend/src/Router.js
@@ -6,6 +6,7 @@ import Creation from 'pages/Creation/Creation';
 import Edit from 'pages/Edit/Edit';
 import GoogleLogin from 'pages/auth/googleLogin';
 import Setting from 'pages/Setting/Setting';
+import MyPosts from 'pages/MyPosts/MyPosts';
 
 const Router = () => {
   return (
@@ -17,6 +18,7 @@ const Router = () => {
         <Route path="edit/:id" element={<Edit />} />
         <Route path="google/callback" element={<GoogleLogin />} />
         <Route path="/setting" element={<Setting />} />
+        <Route path="myposts" element={<MyPosts />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -57,14 +57,13 @@ const CardWrapper = styled.div<{
   margin: 10px 10px;
 
   border: ${({ type }) => {
-    const borderType = type ? type : 'default';
     const borderStyle = {
       primary: `1px solid #F23D3D`,
       additional: `1px solid ${theme.mainViolet}`,
       default: '1px solid #dbdbdb',
     };
 
-    return borderStyle[borderType];
+    return borderStyle[type || 'default'];
   }};
   border-radius: 20px;
   background: white;

--- a/frontend/src/components/Nav/Dropdown.tsx
+++ b/frontend/src/components/Nav/Dropdown.tsx
@@ -20,7 +20,7 @@ const DropdownItem = () => {
   return (
     <Wrapper>
       <ul>
-        <Link to="/">
+        <Link to="/myposts">
           <li>내 작성글</li>
         </Link>
         <Link to="/setting">

--- a/frontend/src/components/Nav/Nav.tsx
+++ b/frontend/src/components/Nav/Nav.tsx
@@ -9,6 +9,8 @@ import Modal from 'components/Modal/Modal';
 import LoginModal from 'components/LoginStep/LoginModal';
 import LoginUser from 'components/Nav/LoginUser';
 
+import { devices } from 'styles/devices';
+
 const Nav = () => {
   const isGetToken = window.localStorage.getItem('accessToken') === null;
   const navigate = useNavigate();
@@ -66,11 +68,19 @@ const Wrapper = styled.div`
   padding: 15px 0;
   border-bottom: 1px solid #dfe1e6;
   background-color: white;
+
+  @media screen and ${devices.mobile} {
+    padding: 0;
+  }
 `;
 
 const NavBox = styled.div`
   ${({ theme }) => theme.flexMixIn('space-between', 'center')}
   padding: 0px 110px;
+
+  @media screen and ${devices.mobile} {
+    padding: 10px;
+  }
 `;
 
 const NavLeft = styled.div`
@@ -85,11 +95,20 @@ const LogoImg = styled.img`
   width: 2.6rem;
   height: 2.6rem;
   margin: 0 10px;
+
+  @media screen and ${devices.mobile} {
+    width: 2rem;
+    height: 2rem;
+  }
 `;
 
 const Logo = styled.span`
   display: inline-block;
   font-size: ${({ theme }) => theme.fontMedium};
+
+  @media screen and ${devices.mobile} {
+    font-size: ${({ theme }) => theme.fontSemiMedium};
+  }
 `;
 
 const NavRight = styled.div`
@@ -102,6 +121,10 @@ const NewPost = styled.div`
 
   &:hover {
     cursor: pointer;
+  }
+
+  @media screen and ${devices.mobile} {
+    font-size: ${({ theme }) => theme.fontSmall};
   }
 `;
 

--- a/frontend/src/components/PostBackButton.tsx
+++ b/frontend/src/components/PostBackButton.tsx
@@ -9,7 +9,7 @@ import { devices } from 'styles/devices';
 const PostBackButton = () => {
   const navigate = useNavigate();
 
-  return <BackButton onClick={() => navigate('/')} />;
+  return <BackButton onClick={() => navigate(-1)} />;
 };
 
 export default PostBackButton;

--- a/frontend/src/components/PostForm/PostForm.model.ts
+++ b/frontend/src/components/PostForm/PostForm.model.ts
@@ -22,6 +22,7 @@ export interface FormModel {
   start_date: moment.Moment;
   flavor?: string;
   status?: string | boolean;
+  id?: string;
 }
 
 export interface PostModel {

--- a/frontend/src/components/PostForm/PostForm.tsx
+++ b/frontend/src/components/PostForm/PostForm.tsx
@@ -91,7 +91,15 @@ const PostForm: FunctionComponent<Props> = ({ mode, defaultPost }: Props) => {
       message.warning('로그인이 만료되었습니다. 다시 로그인 해주세요.');
       return navigate('/');
     }
-  }, [navigate, access]);
+
+    if (
+      mode === 'edit' &&
+      Number(localStorage.getItem('id')) !== Number(defaultPost?.fields?.id)
+    ) {
+      navigate('/');
+      return message.warning('해당 게시글에 대한 권한이 없습니다.');
+    }
+  }, [navigate, access, mode, defaultPost?.fields?.id]);
 
   const EditForm = async (values: FormatModel) => {
     try {

--- a/frontend/src/components/PostForm/PostForm.tsx
+++ b/frontend/src/components/PostForm/PostForm.tsx
@@ -7,16 +7,14 @@ import {
   Button,
   Switch,
 } from 'antd';
-import React, { useState, FunctionComponent, useMemo } from 'react';
-import { useDispatch } from 'react-redux';
-import { clearStep } from 'redux/reducers/loginSlice';
+import React, { useState, FunctionComponent, useMemo, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ImPointRight } from 'react-icons/im';
 import { VscCircleOutline } from 'react-icons/vsc';
 import { Editor } from '@tinymce/tinymce-react';
 import styled from 'styled-components';
 
-import { BASE_URL, TINYMCE_API_KEY } from 'config';
+import { BASE_URL, TINYMCE_API_KEY, getToken } from 'config';
 
 import { OPTIONS } from 'assets/data/Options.constant';
 import customHttp, { AuthVerify } from 'utils/Axios';
@@ -39,10 +37,6 @@ import {
   convertToFormatted,
 } from 'components/PostForm/Post.functions';
 
-import { getToken } from 'config';
-
-import { useEffect } from 'react';
-
 const { Option } = Select;
 const { Item } = Form;
 
@@ -56,7 +50,6 @@ const PostForm: FunctionComponent<Props> = ({ mode, defaultPost }: Props) => {
   const [form] = Form.useForm();
   const { access } = getToken();
   const navigate = useNavigate();
-  const dispatch = useDispatch();
 
   const [additionalCards, setAdditionalCards] = useState<string[]>(
     mode === 'edit' ? defaultPost.additional : [],
@@ -89,12 +82,13 @@ const PostForm: FunctionComponent<Props> = ({ mode, defaultPost }: Props) => {
   );
 
   useEffect(() => {
-    if (
-      access === '' ||
-      access === null ||
-      AuthVerify() === 'Refresh Token Expired'
-    ) {
+    if (access === '' || access === null) {
       message.warning('로그인이 필요합니다.');
+      return navigate('/');
+    }
+
+    if (AuthVerify() === 'Refresh Token Expired') {
+      message.warning('로그인이 만료되었습니다. 다시 로그인 해주세요.');
       return navigate('/');
     }
   }, [navigate, access]);
@@ -111,16 +105,7 @@ const PostForm: FunctionComponent<Props> = ({ mode, defaultPost }: Props) => {
         navigate(`/project/${id}`);
       }
     } catch (err) {
-      console.log(err);
-
-      if (
-        (err as { response: { data: { ERROR: string } } }).response.data
-          ?.ERROR === 'YOUR_LOGIN_HAS_EXPIRED'
-      ) {
-        logout();
-      } else {
-        message.error('게시글이 수정되지 않았습니다.');
-      }
+      message.error('게시글이 수정되지 않았습니다.');
     }
   };
 
@@ -135,16 +120,7 @@ const PostForm: FunctionComponent<Props> = ({ mode, defaultPost }: Props) => {
         navigate(`/project/${id}`);
       }
     } catch (err) {
-      console.log(err);
-
-      if (
-        (err as { response: { data: { ERROR: string } } }).response?.data
-          ?.ERROR === 'YOUR_LOGIN_HAS_EXPIRED'
-      ) {
-        logout();
-      } else {
-        message.error('프로젝트가 생성되지 않았습니다.');
-      }
+      message.error('프로젝트가 생성되지 않았습니다.');
     }
   };
 
@@ -176,13 +152,6 @@ const PostForm: FunctionComponent<Props> = ({ mode, defaultPost }: Props) => {
     const checkbox = e.target as HTMLInputElement;
 
     checkbox.checked && setFlavor(checkbox.name);
-  };
-
-  const logout = () => {
-    message.warn('로그인이 만료되었습니다. 다시 로그인해주세요.');
-    navigate('/');
-    dispatch(clearStep());
-    localStorage.clear();
   };
 
   return (
@@ -514,12 +483,13 @@ const PostForm: FunctionComponent<Props> = ({ mode, defaultPost }: Props) => {
                 init={{
                   referrer_policy: 'origin',
                   export_cors_hosts: [`${BASE_URL}`],
-                  placeholder: '프로젝트에 대해 소개해주세요.',
+                  placeholder:
+                    '프로젝트에 대해 소개해주세요. (이미지를 올리고 싶다면 드래그를 해주세요!)',
                   height: 700,
-                  menubar: false,
                   paste_data_images: true,
+                  menubar: false,
                   toolbar:
-                    'undo redo  | styles | styleselect  | fontsizeselect  | bold italic | alignleft aligncenter alignright alignjustify | outdent indent ',
+                    'undo redo  | styles | styleselect  | forecolor| fontsizeselect  | bold italic | alignleft aligncenter alignright alignjustify | outdent indent | code',
                   resize: false,
                 }}
                 onEditorChange={(content: string) => setDescription(content)}
@@ -528,7 +498,7 @@ const PostForm: FunctionComponent<Props> = ({ mode, defaultPost }: Props) => {
           </DetailInfo>
           <ButtonBox>
             <StyledButton
-              onClick={() => navigate('/')}
+              onClick={() => navigate('/myposts')}
               style={{ background: '#99999' }}
             >
               취소
@@ -550,18 +520,20 @@ export default PostForm;
 
 const Wrapper = styled.div`
   ${({ theme }) => theme.wrapper()}
+  padding : 0 35px;
 
   @media screen and ${devices.laptop} {
-    overflow-x: hidden;
-    width: 900px;
+    width: 800px;
+    padding: 0px;
   }
 
   @media screen and ${devices.tablet} {
-    width: 720px;
+    width: 650px;
   }
 
   @media screen and ${devices.mobile} {
     width: 500px;
+    padding-right: 10px;
   }
 `;
 
@@ -624,6 +596,10 @@ const Line = styled.div`
 const MiddleLine = styled.div`
   width: 100%;
   margin-top: -120px;
+
+  @media screen and ${devices.laptop} {
+    display: block;
+  }
 `;
 
 const Main = styled.main`
@@ -641,11 +617,7 @@ const StatusSwitch = styled(Switch)`
 `;
 
 const SelectList = styled.ul`
-  width: 690px;
-
-  @media screen and ${devices.mobile} {
-    width: 480px;
-  }
+  width: 100%;
 `;
 
 const ListItem = styled(Item)`
@@ -679,6 +651,15 @@ const StyledSelect = styled(Select)`
   border-radius: 3px;
   background-color: #f4f5f7;
   cursor: pointer;
+
+  @media screen and ${devices.tablet} {
+    font-size: 17px;
+    margin-left: 20px;
+  }
+
+  @media screen and ${devices.mobile} {
+    font-size: 15px;
+  }
 `;
 
 const StyledCircle = styled(VscCircleOutline)`
@@ -697,6 +678,15 @@ const ContactInput = styled.input`
   border-radius: 3px;
   background-color: #f4f5f7;
   font-size: 14px;
+
+  @media screen and ${devices.tablet} {
+    font-size: 17px;
+    margin-left: 20px;
+  }
+
+  @media screen and ${devices.mobile} {
+    font-size: 15px;
+  }
 `;
 
 const TagBox = styled.div`
@@ -742,12 +732,20 @@ const CardBox = styled.div`
   border: transparant 1px solid;
   border-radius: 10px;
   background: #f4f5f7;
+
+  @media screen and ${devices.laptop} {
+    width: 550px;
+  }
+
+  @media screen and ${devices.mobile} {
+    width: 440px;
+  }
 `;
 
 const CardBoxLabel = styled.span`
   position: absolute;
   left: 20px;
-  top: -5px;
+  top: -10px;
   font-size: ${theme.fontMicro};
   color: ${theme.mainViolet};
 `;
@@ -759,6 +757,15 @@ const StyledDatePicker = styled(DatePicker)`
   border: 1px transparent solid;
   border-radius: 3px;
   background-color: #f4f5f7;
+
+  @media screen and ${devices.tablet} {
+    font-size: 17px;
+    margin-left: 20px;
+  }
+
+  @media screen and ${devices.mobile} {
+    font-size: 15px;
+  }
 `;
 
 const PickButton = styled(Button)`
@@ -767,15 +774,19 @@ const PickButton = styled(Button)`
   display: block;
   padding: 0 10px;
   height: 35px;
+  transform: translate(-5px, -15px);
   border-radius: 30px;
   border: 0;
   color: #fff;
+  font-size: 16px;
   font-weight: ${theme.weightBold};
   background-color: ${theme.mainViolet};
+
   cursor: pointer;
 
   @media screen and ${devices.laptop} {
-    transform: translate(-70px, -10px);
+    transform: translate(-65px, -15px);
+    font-size: 14px;
   }
 
   @media screen and ${devices.tablet} {
@@ -786,7 +797,7 @@ const PickButton = styled(Button)`
 
 const FlavorBox = styled.div`
   margin: 25px 0;
-  padding: 30px;
+  padding: 30px 20px;
   width: 350px;
   height: 350px;
   background-color: #f4f5f7;
@@ -795,7 +806,7 @@ const FlavorBox = styled.div`
 
   @media screen and ${devices.tablet} {
     margin-top: 50px;
-    transform: translateX(50%);
+    transform: translateX(125px);
   }
 
   @media screen and ${devices.mobile} {
@@ -859,7 +870,7 @@ const DetailInfo = styled.div`
   margin: 80px 0;
 
   @media screen and ${devices.laptop} {
-    margin: 80px 20px 100px 20px;
+    margin: 210px 20px 100px 20px;
   }
 
   @media screen and ${devices.tablet} {

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -11,8 +11,14 @@ const API = {
 };
 
 export const getToken = () => {
-  const access = localStorage.getItem('accessToken');
-  const refresh = localStorage.getItem('refreshToken');
+  // const access = localStorage.getItem('accessToken');
+  // const refresh = localStorage.getItem('refreshToken');
+
+  const access = `eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNjU5OTczMDg3LCJpYXQiOjE2NTk5NjIyODcsImp0aSI6IjZhZDMzMDhmNjcxNjQ4ZjhiMTA5NjY4NzQyZjI5OTkzIiwic3ViIjo5fQ.C46Mu9RfFRAcr8cwE27fBAI2KMiyQZ5pr5vtOX0Eiq4`;
+
+  const refresh =
+    'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTY2MDA0ODY4NywiaWF0IjoxNjU5OTYyMjg3LCJqdGkiOiJhM2JjYWVhZGNiZjY0ZTcxOWRkNjk3MjE4YWNlMjhmMiIsInN1YiI6OX0.jzGcJQaKAlm_xHJkfIEvzt-_XYUr-dE1dQ3SixbyWp0';
+
   const id = localStorage.getItem('id');
 
   return { access, refresh, id };

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -11,13 +11,8 @@ const API = {
 };
 
 export const getToken = () => {
-  // const access = localStorage.getItem('accessToken');
-  // const refresh = localStorage.getItem('refreshToken');
-
-  const access = `eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNjU5OTczMDg3LCJpYXQiOjE2NTk5NjIyODcsImp0aSI6IjZhZDMzMDhmNjcxNjQ4ZjhiMTA5NjY4NzQyZjI5OTkzIiwic3ViIjo5fQ.C46Mu9RfFRAcr8cwE27fBAI2KMiyQZ5pr5vtOX0Eiq4`;
-
-  const refresh =
-    'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTY2MDA0ODY4NywiaWF0IjoxNjU5OTYyMjg3LCJqdGkiOiJhM2JjYWVhZGNiZjY0ZTcxOWRkNjk3MjE4YWNlMjhmMiIsInN1YiI6OX0.jzGcJQaKAlm_xHJkfIEvzt-_XYUr-dE1dQ3SixbyWp0';
+  const access = localStorage.getItem('accessToken');
+  const refresh = localStorage.getItem('refreshToken');
 
   const id = localStorage.getItem('id');
 

--- a/frontend/src/pages/Detail/Detail.tsx
+++ b/frontend/src/pages/Detail/Detail.tsx
@@ -40,6 +40,7 @@ const Detail: FunctionComponent = () => {
 
   useEffect(() => {
     getDetails();
+    window.scrollTo(0, 0);
   }, [getDetails]);
 
   return (

--- a/frontend/src/pages/Detail/Detail.tsx
+++ b/frontend/src/pages/Detail/Detail.tsx
@@ -1,20 +1,18 @@
 import axios from 'axios';
-import { message, Popconfirm, Tag } from 'antd';
+import { Tag, Spin } from 'antd';
+import { LoadingOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import { FiExternalLink } from 'react-icons/fi';
-import { useDispatch } from 'react-redux';
 import React, {
   useEffect,
   useState,
   FunctionComponent,
   useCallback,
 } from 'react';
-import { clearStep } from 'redux/reducers/loginSlice';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { BASE_URL } from 'config';
-import customHttp from 'utils/Axios';
 import Nav from 'components/Nav/Nav';
 import Card from 'components/Card';
 import PostBackButton from 'components/PostBackButton';
@@ -24,17 +22,19 @@ import theme from 'styles/theme';
 import { devices } from 'styles/devices';
 
 const Detail: FunctionComponent = () => {
-  const dispatch = useDispatch();
   const { id } = useParams();
-  const navigate = useNavigate();
   const [detailInfo, setDetailInfo] = useState<DetailModel>();
+  const [isLoading, setIsLoading] = useState(false);
 
   const getDetails = useCallback(async () => {
+    setIsLoading(true);
     try {
       const { data } = await axios.get(`${BASE_URL}/api/posts/${id}`);
       setDetailInfo(data);
     } catch (err) {
       console.log(err);
+    } finally {
+      setIsLoading(false);
     }
   }, [id]);
 
@@ -42,212 +42,172 @@ const Detail: FunctionComponent = () => {
     getDetails();
   }, [getDetails]);
 
-  const deletePost = async () => {
-    try {
-      const res = await customHttp.delete(`${BASE_URL}/api/posts/${id}`);
-
-      if (res.status === 204) {
-        message.success('해당 게시글이 삭제되었습니다.');
-        navigate('/');
-      }
-    } catch (err) {
-      console.log(err);
-
-      if (
-        (err as { response: { data: { ERROR: string } } }).response?.data
-          ?.ERROR === 'YOUR_LOGIN_HAS_EXPIRED'
-      ) {
-        logout();
-      } else if (
-        (err as { response: { data: string } }).response.data ===
-        'POST_DOES_NOT_EXIST'
-      )
-        message.error('해당 게시글은 이미 삭제되었습니다.');
-      else message.error('해당 게시글이 삭제되지 않았습니다.');
-    }
-  };
-
-  const goToEdit = () => {
-    navigate(`/edit/${id}`);
-  };
-
-  const logout = () => {
-    message.warn('로그인이 만료되었습니다. 다시 로그인해주세요.');
-    navigate('/');
-    dispatch(clearStep());
-    localStorage.clear();
-  };
-
   return (
     <>
       <Nav />
-      <Wrapper>
-        <Header>
-          <PostBackButton />
-          <HeaderTitle>
-            {detailInfo?.title}
-            <TitleLine />
-          </HeaderTitle>
-          <HeaderInfo>
-            <UserInfo>
-              <Profile
-                src={
-                  detailInfo?.user?.image_url ||
-                  'https://i.ibb.co/0CNSQWx/profile.png'
-                }
-              />
-              <span>
-                {detailInfo?.user?.ordinal_number}기 {detailInfo?.user?.name}
-              </span>
-            </UserInfo>
-            <Date>
-              {dayjs(detailInfo?.created_at).format(
-                'YYYY년 mm월 DD일 HH:mm:ss',
+      {isLoading ? (
+        <div style={{ position: 'absolute', top: '45%', right: '45%' }}>
+          <Spin indicator={<LoadingOutlined style={{ fontSize: '40px' }} />} />
+        </div>
+      ) : (
+        <Wrapper>
+          <Header>
+            <PostBackButton />
+            <HeaderTitle>
+              {detailInfo?.title}
+              <TitleLine />
+            </HeaderTitle>
+            <HeaderInfo>
+              <UserInfo>
+                <Profile
+                  src={
+                    detailInfo?.user?.image_url ||
+                    'https://i.ibb.co/0CNSQWx/profile.png'
+                  }
+                />
+                <span>
+                  {detailInfo?.user?.ordinal_number}기 {detailInfo?.user?.name}
+                </span>
+              </UserInfo>
+              <Date>
+                {dayjs(detailInfo?.created_at).format(
+                  'YYYY년 MM월 DD일 HH:mm:ss',
+                )}
+              </Date>
+              {detailInfo?.status === 'active' ? (
+                <StatusTag color="blue">현재 모집 중</StatusTag>
+              ) : (
+                <StatusTag color="gray">모집 마감</StatusTag>
               )}
-            </Date>
-            {detailInfo?.status === 'active' ? (
-              <StatusTag color="blue">현재 모집 중</StatusTag>
-            ) : (
-              <StatusTag color="gray">모집 마감</StatusTag>
-            )}
-          </HeaderInfo>
-        </Header>
-        <Line />
-        <BasicInfo>
-          <Title>
-            <Num>1</Num>프로젝트 레시피
-            <Spicy>
-              맵기 단계
-              <Flavor>
-                <FlavorImg
-                  alt="pepper"
-                  src={detailInfo?.post_flavor?.image_url}
-                />
-                {detailInfo?.post_flavor?.title}
-                <FlavorDetail>{`(${detailInfo?.post_flavor?.description})`}</FlavorDetail>
-              </Flavor>
-            </Spicy>
-          </Title>
-          <InfoList>
-            <ListSection>
-              <ListItem>
-                <ItemTitle>프로젝트 타입</ItemTitle>
-                <Content>{detailInfo?.category}</Content>
-              </ListItem>
-              <ListItem>
-                <ItemTitle>진행 방식 </ItemTitle>
-                <Content>{detailInfo?.post_place.title}</Content>
-              </ListItem>
-              <ListItem>
-                <ItemTitle>프론트엔드 모집 인원</ItemTitle>
-                <Content>{detailInfo?.number_of_front}</Content>
-              </ListItem>
-              <ListItem>
-                <ItemTitle>백엔드 모집 인원</ItemTitle>
-                <Content>{detailInfo?.number_of_back}</Content>
-              </ListItem>
-            </ListSection>
-            <ListSection>
-              <ListItem>
-                <ItemTitle>기술 스택</ItemTitle>
-                <Content>
-                  {detailInfo?.post_stack?.map(({ image_url }, idx) => (
-                    <Stackimage key={idx} src={image_url} />
-                  ))}
-                </Content>
-              </ListItem>
-              <ListItem>
-                <ItemTitle>진행 기간</ItemTitle>
-                <Content>{detailInfo?.period}</Content>
-              </ListItem>
-              <ListItem>
-                <ItemTitle>시작 예정일</ItemTitle>
-                <Content>
-                  {dayjs(detailInfo?.start_date).format('YYYY-MM-DD')}
-                </Content>
-              </ListItem>
-              <ListItem>
-                <ItemTitle>연락 방법</ItemTitle>
-                <Content>{detailInfo?.post_applyway.title}</Content>
-              </ListItem>
-              <ListItem>
-                <ItemTitle>연락할 곳</ItemTitle>
-                <Content>
-                  {detailInfo?.post_applyway.title !== '이메일' ? (
-                    <ExternalLink
-                      target="_blank"
-                      rel="noreferrer"
-                      href={detailInfo?.post_applyway.description}
-                    >
-                      {detailInfo?.post_applyway.description}
-                      <FiExternalLink />
-                    </ExternalLink>
-                  ) : (
-                    detailInfo?.post_applyway.description
-                  )}
-                </Content>
-              </ListItem>
-            </ListSection>
-          </InfoList>
-        </BasicInfo>
-        <PersonalityList>
-          <SemiTitle>
-            <Salad src="https://i.ibb.co/PrKjyH6/salad.png" />
-            우리는 이런 재료를 가진 팀원들과 함께 하고 싶어요.
-          </SemiTitle>
-          <CardBox>
-            {detailInfo?.post_answer?.[0]?.primary_answer?.map(
-              ({ description, image_url }) => (
-                <Card
-                  id={description}
-                  key={description}
-                  image_url={image_url}
-                  name={description}
-                />
-              ),
-            )}
-
-            {detailInfo?.post_answer?.[0]?.secondary_answer?.map(
-              ({ description, image_url }) => (
-                <Card
-                  id={description}
-                  key={description}
-                  image_url={image_url}
-                  name={description}
-                />
-              ),
-            )}
-          </CardBox>
-        </PersonalityList>
-        <Introduction>
-          <Title>
-            <Num>2</Num>프로젝트 소개
-          </Title>
-          <Line></Line>
-          <MainContent>
-            {detailInfo?.description ? (
-              <div
-                dangerouslySetInnerHTML={{
-                  __html: detailInfo?.description,
-                }}
-              ></div>
-            ) : (
-              ''
-            )}
-          </MainContent>
+            </HeaderInfo>
+          </Header>
           <Line />
-        </Introduction>
-        {localStorage.getItem('id') !== undefined &&
-          Number(localStorage.getItem('id')) ===
-            Number(detailInfo?.user.id) && (
-            <>
-              <EditButton onClick={goToEdit}>수정</EditButton>
-              <Popconfirm title="삭제하시겠습니까?" onConfirm={deletePost}>
-                <DeleteButton>삭제</DeleteButton>
-              </Popconfirm>
-            </>
-          )}
-      </Wrapper>
+          <BasicInfo>
+            <Title>
+              <Num>1</Num>프로젝트 레시피
+              <Spicy>
+                맵기 단계
+                <Flavor>
+                  <FlavorImg
+                    alt="pepper"
+                    src={detailInfo?.post_flavor?.image_url}
+                  />
+                  {detailInfo?.post_flavor?.title}
+                  <FlavorDetail>{`(${detailInfo?.post_flavor?.description})`}</FlavorDetail>
+                </Flavor>
+              </Spicy>
+            </Title>
+            <InfoList>
+              <ListSection>
+                <ListItem>
+                  <ItemTitle>프로젝트 타입</ItemTitle>
+                  <Content>{detailInfo?.category}</Content>
+                </ListItem>
+                <ListItem>
+                  <ItemTitle>진행 방식 </ItemTitle>
+                  <Content>{detailInfo?.post_place.title}</Content>
+                </ListItem>
+                <ListItem>
+                  <ItemTitle>프론트엔드 모집 인원</ItemTitle>
+                  <Content>{detailInfo?.number_of_front}</Content>
+                </ListItem>
+                <ListItem>
+                  <ItemTitle>백엔드 모집 인원</ItemTitle>
+                  <Content>{detailInfo?.number_of_back}</Content>
+                </ListItem>
+              </ListSection>
+              <ListSection>
+                <ListItem>
+                  <ItemTitle>기술 스택</ItemTitle>
+                  <Content>
+                    {detailInfo?.post_stack?.map(({ image_url }, idx) => (
+                      <Stackimage key={idx} src={image_url} />
+                    ))}
+                  </Content>
+                </ListItem>
+                <ListItem>
+                  <ItemTitle>진행 기간</ItemTitle>
+                  <Content>{detailInfo?.period}</Content>
+                </ListItem>
+                <ListItem>
+                  <ItemTitle>시작 예정일</ItemTitle>
+                  <Content>
+                    {dayjs(detailInfo?.start_date).format('YYYY-MM-DD')}
+                  </Content>
+                </ListItem>
+                <ListItem>
+                  <ItemTitle>연락 방법</ItemTitle>
+                  <Content>{detailInfo?.post_applyway.title}</Content>
+                </ListItem>
+                <ListItem>
+                  <ItemTitle>연락할 곳</ItemTitle>
+                  <Content>
+                    {detailInfo?.post_applyway.title !== '이메일' ? (
+                      <ExternalLink
+                        target="_blank"
+                        rel="noreferrer"
+                        href={detailInfo?.post_applyway.description}
+                      >
+                        {detailInfo?.post_applyway.description}
+                        <FiExternalLink />
+                      </ExternalLink>
+                    ) : (
+                      detailInfo?.post_applyway.description
+                    )}
+                  </Content>
+                </ListItem>
+              </ListSection>
+            </InfoList>
+          </BasicInfo>
+          <PersonalityList>
+            <SemiTitle>
+              <Salad src="https://i.ibb.co/PrKjyH6/salad.png" />
+              우리는 이런 재료를 가진 팀원들과 함께 하고 싶어요.
+            </SemiTitle>
+            <CardBox>
+              {detailInfo?.post_answer?.[0]?.primary_answer?.map(
+                ({ description, image_url }) => (
+                  <Card
+                    id={description}
+                    key={description}
+                    image_url={image_url}
+                    name={description}
+                  />
+                ),
+              )}
+
+              {detailInfo?.post_answer?.[0]?.secondary_answer?.map(
+                ({ description, image_url }) => (
+                  <Card
+                    id={description}
+                    key={description}
+                    image_url={image_url}
+                    name={description}
+                  />
+                ),
+              )}
+            </CardBox>
+          </PersonalityList>
+          <Introduction>
+            <Title>
+              <Num>2</Num>프로젝트 소개
+            </Title>
+            <Line></Line>
+            <MainContent>
+              {detailInfo?.description ? (
+                <div
+                  dangerouslySetInnerHTML={{
+                    __html: detailInfo?.description,
+                  }}
+                ></div>
+              ) : (
+                ''
+              )}
+            </MainContent>
+            <Line />
+          </Introduction>
+        </Wrapper>
+      )}
     </>
   );
 };
@@ -259,18 +219,18 @@ const Wrapper = styled.div`
   position: relative;
 
   @media screen and ${devices.laptop} {
-    overflow-x: hidden;
-    width: 900px;
+    width: 800px;
+    padding: 0 40px;
   }
 
   @media screen and ${devices.tablet} {
-    overflow-x: hidden;
-    width: 720px;
+    width: 600px;
+    padding: 0;
   }
 
   @media screen and ${devices.mobile} {
-    overflow-x: hidden;
     width: 500px;
+    padding: 0;
   }
 `;
 
@@ -289,19 +249,19 @@ const HeaderTitle = styled.h1`
 
   @media screen and ${devices.mobile} {
     margin: 10px 0;
+    font-size: 30px;
   }
 `;
 
 const TitleLine = styled.div`
   position: absolute;
   bottom: 10px;
-  width: 100%;
+  width: 90%;
   height: 15px;
   background-color: ${theme.mainGreen};
   z-index: -1;
 
   @media screen and ${devices.mobile} {
-    width: 80%;
     height: 12px;
   }
 `;
@@ -326,6 +286,10 @@ const UserInfo = styled.div`
   @media screen and ${devices.laptop} {
     margin: 10px 20px;
   }
+
+  @media screen and ${devices.mobile} {
+    font-size: 15px;
+  }
 `;
 
 const Profile = styled.img`
@@ -342,6 +306,10 @@ const Profile = styled.img`
 
 const Date = styled.div`
   color: #999999;
+
+  @media screen and ${devices.mobile} {
+    font-size: 15px;
+  }
 `;
 
 const Line = styled.div`
@@ -585,59 +553,4 @@ const MainContent = styled.div`
   font-family: ‘Black Han Sans’, sans-serif;
   padding: 20px;
   line-height: 30px;
-`;
-
-const EditButton = styled.button`
-  position: absolute;
-  right: 100px;
-  bottom: -40px;
-  margin-bottom: 20px;
-  padding: 10px 20px;
-  background: ${theme.mainGreen};
-  font-size: ${theme.fontRegular};
-  color: #fff;
-  border: 0;
-  border-radius: 10px;
-  cursor: pointer;
-
-  @media screen and ${devices.laptop} {
-    bottom: -10px;
-  }
-
-  @media screen and ${devices.tablet} {
-    bottom: -20px;
-  }
-
-  @media screen and ${devices.mobile} {
-    right: 90px;
-    bottom: 0;
-    padding: 7px 15px;
-  }
-`;
-
-const DeleteButton = styled.button`
-  position: absolute;
-  right: 20px;
-  bottom: -40px;
-  padding: 10px 20px;
-  margin-bottom: 20px;
-  background: #999;
-  font-size: ${theme.fontRegular};
-  color: #fff;
-  border: 0;
-  border-radius: 10px;
-  cursor: pointer;
-
-  @media screen and ${devices.laptop} {
-    bottom: -10px;
-  }
-
-  @media screen and ${devices.tablet} {
-    bottom: -20px;
-  }
-
-  @media screen and ${devices.mobile} {
-    bottom: 0;
-    padding: 7px 15px;
-  }
 `;

--- a/frontend/src/pages/Edit/Edit.tsx
+++ b/frontend/src/pages/Edit/Edit.tsx
@@ -1,35 +1,45 @@
-import { Spin } from 'antd';
-
+import { Spin, message } from 'antd';
+import { LoadingOutlined } from '@ant-design/icons';
 import axios from 'axios';
 import moment from 'moment';
-import React, { FunctionComponent, useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import React, {
+  FunctionComponent,
+  useEffect,
+  useState,
+  useCallback,
+} from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
 
 import { BASE_URL } from 'config';
 
 import PostForm from 'components/PostForm/PostForm';
 
-import type { DetailModel } from 'pages/Detail/Detail.model';
 import type { PostModel } from 'components/PostForm/PostForm.model';
-
-import { LoadingOutlined } from '@ant-design/icons';
+import type { DetailModel } from 'pages/Detail/Detail.model';
 
 const Edit: FunctionComponent = () => {
   const { id } = useParams();
+  const navigate = useNavigate();
 
   const [postToEdit, setPostToEdit] = useState<PostModel>();
 
-  useEffect(() => {
-    const getData = async () => {
-      try {
-        const { data } = await axios.get(`${BASE_URL}/api/posts/${id}`);
-        convertToPostData(data);
-      } catch (err) {
-        console.log(err);
-      }
-    };
-    getData();
+  const getData = useCallback(async () => {
+    try {
+      const { data } = await axios.get(`${BASE_URL}/api/posts/${id}`);
+      convertToPostData(data);
+    } catch (err) {
+      console.log(err);
+    }
   }, [id]);
+
+  useEffect(() => {
+    if (Number(localStorage.getItem('id')) !== Number(id)) {
+      navigate('/');
+      return message.warning('해당 게시글에 대한 권한이 없습니다.');
+    } else {
+      getData();
+    }
+  }, [id, navigate, getData]);
 
   const convertToPostData = (data: DetailModel) => {
     const {

--- a/frontend/src/pages/Edit/Edit.tsx
+++ b/frontend/src/pages/Edit/Edit.tsx
@@ -19,27 +19,20 @@ import type { DetailModel } from 'pages/Detail/Detail.model';
 
 const Edit: FunctionComponent = () => {
   const { id } = useParams();
-  const navigate = useNavigate();
 
   const [postToEdit, setPostToEdit] = useState<PostModel>();
 
-  const getData = useCallback(async () => {
-    try {
-      const { data } = await axios.get(`${BASE_URL}/api/posts/${id}`);
-      convertToPostData(data);
-    } catch (err) {
-      console.log(err);
-    }
-  }, [id]);
-
   useEffect(() => {
-    if (Number(localStorage.getItem('id')) !== Number(id)) {
-      navigate('/');
-      return message.warning('해당 게시글에 대한 권한이 없습니다.');
-    } else {
-      getData();
-    }
-  }, [id, navigate, getData]);
+    const getData = async () => {
+      try {
+        const { data } = await axios.get(`${BASE_URL}/api/posts/${id}`);
+        convertToPostData(data);
+      } catch (err) {
+        console.log(err);
+      }
+    };
+    getData();
+  }, [id]);
 
   const convertToPostData = (data: DetailModel) => {
     const {
@@ -56,6 +49,7 @@ const Edit: FunctionComponent = () => {
       title,
       post_flavor,
       status,
+      user,
     } = data;
 
     const fields = {
@@ -71,6 +65,7 @@ const Edit: FunctionComponent = () => {
       start_date: moment(start_date, 'YYYY-MM-DD'),
       flavor: post_flavor?.title,
       status: status === 'active' ? true : false,
+      id: user.id,
     };
 
     const primary =

--- a/frontend/src/pages/Edit/Edit.tsx
+++ b/frontend/src/pages/Edit/Edit.tsx
@@ -1,3 +1,5 @@
+import { Spin } from 'antd';
+
 import axios from 'axios';
 import moment from 'moment';
 import React, { FunctionComponent, useEffect, useState } from 'react';
@@ -10,6 +12,8 @@ import PostForm from 'components/PostForm/PostForm';
 import type { DetailModel } from 'pages/Detail/Detail.model';
 import type { PostModel } from 'components/PostForm/PostForm.model';
 
+import { LoadingOutlined } from '@ant-design/icons';
+
 const Edit: FunctionComponent = () => {
   const { id } = useParams();
 
@@ -19,7 +23,6 @@ const Edit: FunctionComponent = () => {
     const getData = async () => {
       try {
         const { data } = await axios.get(`${BASE_URL}/api/posts/${id}`);
-
         convertToPostData(data);
       } catch (err) {
         console.log(err);
@@ -57,7 +60,7 @@ const Edit: FunctionComponent = () => {
       period,
       start_date: moment(start_date, 'YYYY-MM-DD'),
       flavor: post_flavor?.title,
-      status,
+      status: status === 'active' ? true : false,
     };
 
     const primary =
@@ -73,7 +76,15 @@ const Edit: FunctionComponent = () => {
   };
 
   return (
-    <>{postToEdit && <PostForm mode="edit" defaultPost={postToEdit} />} </>
+    <>
+      {postToEdit ? (
+        <PostForm mode="edit" defaultPost={postToEdit} />
+      ) : (
+        <div style={{ position: 'absolute', top: '45%', right: '45%' }}>
+          <Spin indicator={<LoadingOutlined style={{ fontSize: '40px' }} />} />
+        </div>
+      )}
+    </>
   );
 };
 

--- a/frontend/src/pages/MyPosts/MyPosts.tsx
+++ b/frontend/src/pages/MyPosts/MyPosts.tsx
@@ -1,0 +1,229 @@
+import { message, Table, Tag, Space, Popconfirm, Spin } from 'antd';
+import { LoadingOutlined } from '@ant-design/icons';
+import dayjs from 'dayjs';
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router';
+import styled from 'styled-components';
+import theme from 'styles/theme';
+
+import { getToken } from 'config';
+import Nav from 'components/Nav/Nav';
+import customHttp, { AuthVerify } from 'utils/Axios';
+import { DetailModel } from 'pages/Detail/Detail.model';
+
+import { devices } from 'styles/devices';
+
+const MyPosts = () => {
+  const navigate = useNavigate();
+  const { access } = getToken();
+  const [myposts, setMyposts] = useState<DetailModel[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (access === '' || access === null) {
+      message.warning('로그인이 필요합니다.');
+      return navigate('/');
+    }
+
+    if (AuthVerify() === 'Refresh Token Expired') {
+      message.warning('로그인이 만료되었습니다. 다시 로그인 해주세요.');
+      return navigate('/');
+    }
+  }, [navigate, access]);
+
+  useEffect(() => {
+    getMyPosts();
+  }, []);
+
+  const getMyPosts = async () => {
+    setIsLoading(true);
+    try {
+      const { data } = await customHttp.get(`/api/users/posts`);
+      setMyposts(
+        data
+          .filter(({ status }: { status: string }) => status !== 'deleted')
+          .sort((a: DetailModel, b: DetailModel) => b.id - a.id),
+      );
+    } catch (err) {
+      console.log(err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const deletePost = async (id: string) => {
+    try {
+      const res = await customHttp.delete(`/api/posts/${id}`);
+
+      if (res.status === 204) {
+        message.success('해당 게시글이 삭제되었습니다.');
+        getMyPosts();
+      }
+    } catch (err) {
+      if (
+        (err as { response: { data: string } }).response.data ===
+        'POST_DOES_NOT_EXIST'
+      )
+        message.error('해당 게시글은 이미 삭제되었습니다.');
+      else
+        message.error('해당 게시글이 삭제되지 않았습니다. 다시 시도해주세요.');
+    }
+  };
+
+  const columns = [
+    {
+      title: <ColumnsTitle>번호</ColumnsTitle>,
+      dataIndex: 'id',
+      key: 'id',
+      render: (id: string) => <ColumnsContent>{id}</ColumnsContent>,
+    },
+    {
+      title: <ColumnsTitle>제목</ColumnsTitle>,
+      dataIndex: 'title',
+      key: 'title',
+      render: (title: string) => <ColumnsContent>{title}</ColumnsContent>,
+    },
+    {
+      title: <ColumnsTitle>작성일</ColumnsTitle>,
+      dataIndex: 'created_at',
+      key: 'created_at',
+      render: (date: string) => (
+        <ColumnsContent>
+          {dayjs(date).format('YYYY년 MM월 DD일 ')}
+        </ColumnsContent>
+      ),
+    },
+    {
+      title: <ColumnsTitle>상태</ColumnsTitle>,
+      dataIndex: 'status',
+      key: 'status',
+      render: (status: string) =>
+        status === 'active' ? (
+          <Tag color="blue">현재 모집 중</Tag>
+        ) : (
+          <Tag color="gray">모집 마감</Tag>
+        ),
+    },
+    {
+      title: <ColumnsTitle>설정</ColumnsTitle>,
+      dataIndex: 'id',
+      key: 'settings',
+      textAlign: 'center',
+      render: (id: string) => (
+        <Space>
+          <Button name="edit" onClick={() => navigate(`/edit/${id}`)}>
+            수정
+          </Button>
+          <Popconfirm
+            title="삭제하시겠습니까?"
+            okText="예"
+            cancelText="아니오"
+            onConfirm={() => deletePost(id)}
+          >
+            <Button name="delete">삭제</Button>
+          </Popconfirm>
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <div>
+      <Nav />
+      <Wrapper>
+        <Title>내 작성글</Title>
+        {!isLoading ? (
+          <Table
+            columns={columns}
+            dataSource={myposts}
+            rowKey={({ id }) => id}
+            style={{ fontSize: '3px' }}
+            scroll={{ x: 'max-content' }}
+            onRow={({ id }) => {
+              return {
+                onClick: (e) => {
+                  if ((e.target as Element).closest('button')) return;
+                  navigate(`/project/${id}`);
+                },
+              };
+            }}
+          />
+        ) : (
+          <div style={{ position: 'absolute', top: '45%', right: '45%' }}>
+            <Spin
+              indicator={<LoadingOutlined style={{ fontSize: '40px' }} />}
+            />
+          </div>
+        )}
+      </Wrapper>
+    </div>
+  );
+};
+
+export default MyPosts;
+
+const Wrapper = styled.div`
+  ${theme.wrapper()};
+  padding: 6rem;
+
+  @media screen and ${devices.laptop} {
+    width: 800px;
+    padding: 6rem 40px;
+  }
+
+  @media screen and ${devices.tablet} {
+    width: 600px;
+    padding: 6rem 10px;
+  }
+
+  @media screen and ${devices.mobile} {
+    width: 500px;
+  }
+`;
+
+const Title = styled.h1`
+  @media screen and ${devices.tablet} {
+    font-size: ${theme.fontMedium};
+  }
+`;
+
+const ColumnsTitle = styled.div`
+  @media screen and ${devices.tablet} {
+    font-size: 15px;
+  }
+
+  @media screen and ${devices.mobile} {
+    font-size: 13px;
+  }
+`;
+
+const ColumnsContent = styled.div`
+  color: #404040;
+  @media screen and ${devices.tablet} {
+    font-size: 14px;
+  }
+
+  @media screen and ${devices.mobile} {
+    font-size: 13px;
+  }
+`;
+
+const Button = styled.button<{ name?: 'edit' | 'delete' }>`
+  margin-right: ${({ name }) => (name === 'edit' ? '0' : '-40px')};
+  padding: 5px 10px;
+  background: ${({ name }) => (name === 'edit' ? theme.mainGreen : 'gray')};
+  font-size: ${theme.fontRegular};
+  color: #fff;
+  border: 0;
+  border-radius: 10px;
+  cursor: pointer;
+
+  @media screen and ${devices.laptop} {
+    margin-right: ${({ name }) => (name === 'edit' ? '0' : '-20px')};
+  }
+
+  @media screen and ${devices.tablet} {
+    padding: 4px;
+    font-size: 14px;
+  }
+`;

--- a/frontend/src/utils/Axios.ts
+++ b/frontend/src/utils/Axios.ts
@@ -1,4 +1,5 @@
-import axios, { AxiosResponse } from 'axios';
+import { message } from 'antd';
+import axios, { AxiosError, AxiosResponse } from 'axios';
 
 import { getToken, BASE_URL, setAccessToken } from 'config';
 
@@ -47,6 +48,18 @@ export const onFulfilled = async (res: AxiosResponse) => {
   } else return res;
 };
 
+const onRejected = (err: AxiosError) => {
+  console.log(err);
+  if (
+    (err as { response: { data: { ERROR: string } } }).response?.data?.ERROR ===
+    'YOUR_LOGIN_HAS_EXPIRED'
+  ) {
+    localStorage.clear();
+    window.location.replace(BASE_URL);
+    return message.warn('로그인이 만료되었습니다. 다시 로그인해주세요.');
+  } else return err;
+};
+
 customHttp.interceptors.request.use(
   (config) => {
     config.headers = {
@@ -59,6 +72,6 @@ customHttp.interceptors.request.use(
   (err) => Promise.reject(err),
 );
 
-customHttp.interceptors.response.use(onFulfilled);
+customHttp.interceptors.response.use(onFulfilled, onRejected);
 
 export default customHttp;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- 본인이 작성한 게시글 조회할 수 있는 My posts 페이지 생성 및 레이아웃 완료 
- 반응형 구현 및 상세 페이지, nav 바도 조금씩 반응형 수정하였음. 

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
**본인이 작성한 게시글 조회할 수 있는 My posts 페이지 생성 및 레이아웃 완료**
- antd table 을 활용하여 리스트들을 렌더링 하였음.  로딩을 하는 동안은 antd 의 spin을 활용하여 사용자경험이 좋아지게끔 하였음. 
- 글 list 클릭 시 해당 글 상세 조회 
- 삭제 버튼 클릭 시 삭제, 수정 기능 클릭 시 수정 페이지로 이동 
- 반응형 구현 
- 기타 ) axios interceptors에서 토큰 만료 처리, 다른 페이지들 반응형 구현 보완 등 














