### PR TITLE
postForm margin top 추가 및 global style내의 Jua 글꼴 삭제

### DIFF
--- a/frontend/src/components/PostForm/PostForm.tsx
+++ b/frontend/src/components/PostForm/PostForm.tsx
@@ -515,15 +515,19 @@ export default PostForm;
 
 const Wrapper = styled.div`
   ${({ theme }) => theme.wrapper()}
-  padding : 0 35px;
+  margin-top : 150px;
+  padding: 0 35px;
   overflow-x: hidden;
 
   @media screen and ${devices.laptop} {
+    margin-top: 10px;
+
     width: 800px;
     padding: 0px;
   }
 
   @media screen and ${devices.tablet} {
+    margin-top: 0px;
     width: 650px;
   }
 

--- a/frontend/src/styles/GlobalStyle.ts
+++ b/frontend/src/styles/GlobalStyle.ts
@@ -4,13 +4,12 @@ const GlobalStyle = createGlobalStyle`
 * {
   box-sizing: border-box; 
   outline: none;
-  font-family: 'Jua', sans-serif;
 }
 
 body{
   box-sizing: border-box; 
   outline: none;
-  font-family: 'Jua', sans-serif;
+ font-family: 'Jua', sans-serif;
 }
 
 img{


### PR DESCRIPTION
변경 사항
* postform 내의 문구 보이지 않던 버그 - margin top 추가로 수정 
* description 글꼴 jua는 가독성이 떨어지기 때문의 기존의 방식대로  GlobalStyle 내의 *선택자에서 jua 글꼴 삭제 