### PR TITLE
Fix : 스터디, 프로젝트를 구분하여 문구 표시, 내 작성글 내 번호 삭제 등

### DIFF
--- a/frontend/src/components/PostBackButton.tsx
+++ b/frontend/src/components/PostBackButton.tsx
@@ -9,7 +9,7 @@ import { devices } from 'styles/devices';
 const PostBackButton = () => {
   const navigate = useNavigate();
 
-  return <BackButton onClick={() => navigate(-1)} />;
+  return <BackButton onClick={() => navigate('/')} />;
 };
 
 export default PostBackButton;

--- a/frontend/src/components/PostForm/PostForm.tsx
+++ b/frontend/src/components/PostForm/PostForm.tsx
@@ -211,7 +211,7 @@ const PostForm: FunctionComponent<Props> = ({ mode, defaultPost }: Props) => {
                   label={
                     <StyledLabel>
                       <StyledCircle />
-                      &nbsp; 프로젝트 타입
+                      &nbsp; 모집 구분
                     </StyledLabel>
                   }
                   colon={false}

--- a/frontend/src/pages/Detail/Detail.tsx
+++ b/frontend/src/pages/Detail/Detail.tsx
@@ -85,7 +85,8 @@ const Detail: FunctionComponent = () => {
           <Line />
           <BasicInfo>
             <Title>
-              <Num>1</Num>프로젝트 레시피
+              <Num>1</Num>
+              {detailInfo?.category} 레시피
               <Spicy>
                 맵기 단계
                 <Flavor>
@@ -101,7 +102,7 @@ const Detail: FunctionComponent = () => {
             <InfoList>
               <ListSection>
                 <ListItem>
-                  <ItemTitle>프로젝트 타입</ItemTitle>
+                  <ItemTitle>모집 구분</ItemTitle>
                   <Content>{detailInfo?.category}</Content>
                 </ListItem>
                 <ListItem>
@@ -201,7 +202,7 @@ const Detail: FunctionComponent = () => {
           </PersonalityList>
           <Introduction>
             <Title>
-              <Num>2</Num>프로젝트 소개
+              <Num>2</Num> {detailInfo?.category} 소개
             </Title>
             <Line></Line>
             <MainContent>

--- a/frontend/src/pages/Detail/Detail.tsx
+++ b/frontend/src/pages/Detail/Detail.tsx
@@ -202,7 +202,8 @@ const Detail: FunctionComponent = () => {
           </PersonalityList>
           <Introduction>
             <Title>
-              <Num>2</Num> {detailInfo?.category} 소개
+              <Num>2</Num>
+              {detailInfo?.category} 소개
             </Title>
             <Line></Line>
             <MainContent>

--- a/frontend/src/pages/MyPosts/MyPosts.tsx
+++ b/frontend/src/pages/MyPosts/MyPosts.tsx
@@ -72,12 +72,6 @@ const MyPosts = () => {
 
   const columns = [
     {
-      title: <ColumnsTitle>번호</ColumnsTitle>,
-      dataIndex: 'id',
-      key: 'id',
-      render: (id: string) => <ColumnsContent>{id}</ColumnsContent>,
-    },
-    {
       title: <ColumnsTitle>제목</ColumnsTitle>,
       dataIndex: 'title',
       key: 'title',
@@ -138,7 +132,6 @@ const MyPosts = () => {
             dataSource={myposts}
             rowKey={({ id }) => id}
             style={{ fontSize: '3px' }}
-            scroll={{ x: 'max-content' }}
           />
         ) : (
           <div style={{ position: 'absolute', top: '45%', right: '45%' }}>
@@ -156,10 +149,10 @@ export default MyPosts;
 
 const Wrapper = styled.div`
   ${theme.wrapper()};
-  padding: 6rem;
+  padding: 6rem 3rem;
 
   @media screen and ${devices.laptop} {
-    width: 800px;
+    width: 900px;
     padding: 6rem 40px;
   }
 


### PR DESCRIPTION
피드백 반영한 수정사항 
* 뒤로가기 버튼 : 메인으로 가는 버튼으로 기능구현하는 것으로 수정
* 스터디, 프로젝트 구분을 위해 상세 페이지 내에서 스터디/프로젝트 타입을 구분하여 '스터디 레시피', '프로젝트 레시피'로 보여주도록 변경 
* 내 작성글 내의 번호 부분 삭제 - user들에게 불필요한 정보라 판단 